### PR TITLE
Content-negotiation in the browser

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,13 @@
+0.6.0 (2018-10-12)
+==================
+
+* It's now possible to get alternative representations in a browser with the
+  `?_browser-accept` query parameter.
+* Links with the `alternate` rel that are local, automatically get the
+  `?_browser-accept` parameter added, so a single resource can now have
+  multiple representations on the same url.
+
+
 0.5.6 (2018-10-04)
 ==================
 

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@
 * Links with the `alternate` rel that are local, automatically get the
   `?_browser-accept` parameter added, so a single resource can now have
   multiple representations on the same url.
+* Now using a new package for parsing HTTP Link urls. The old one didn't
+  support multiple links with the same `rel`.
 
 
 0.5.6 (2018-10-04)

--- a/package-lock.json
+++ b/package-lock.json
@@ -169,6 +169,12 @@
       "integrity": "sha512-pGF/zvYOACZ/gLGWdQH8zSwteQS1epp68yRcVLJMgUck/MjEn/FBYmPub9pXT8C1e4a8YZfHo1CKyV8q1vKUnQ==",
       "dev": true
     },
+    "@types/http-link-header": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@types/http-link-header/-/http-link-header-0.6.2.tgz",
+      "integrity": "sha512-uIhrzrjjGlsyUbhRwCDR138OJxX9+uVECym0cLEdCdnZs4LmJreqIxOl1leHXK/0Ql5O/TlLf6fbDa6r5u6Z7w==",
+      "dev": true
+    },
     "@types/markdown-it": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-0.0.5.tgz",
@@ -185,12 +191,6 @@
       "version": "10.11.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.11.4.tgz",
       "integrity": "sha512-ojnbBiKkZFYRfQpmtnnWTMw+rzGp/JiystjluW9jgN3VzRwilXddJ6aGQ9V/7iuDG06SBgn7ozW9k3zcAnYjYQ==",
-      "dev": true
-    },
-    "@types/parse-link-header": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@types/parse-link-header/-/parse-link-header-1.0.0.tgz",
-      "integrity": "sha512-fCA3btjE7QFeRLfcD0Sjg+6/CnmC66HpMBoRfRzd2raTaWMJV21CCZ0LO8MOqf8onl5n0EPfjq4zDhbyX8SVwA==",
       "dev": true
     },
     "@types/sinon": {
@@ -515,6 +515,11 @@
         "setprototypeof": "1.1.0",
         "statuses": ">= 1.4.0 < 2"
       }
+    },
+    "http-link-header": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/http-link-header/-/http-link-header-0.8.0.tgz",
+      "integrity": "sha1-oitBoMmx4tj6wb8baXxr1TLV9eQ="
     },
     "iconv-lite": {
       "version": "0.4.23",
@@ -3059,14 +3064,6 @@
         "wrappy": "1"
       }
     },
-    "parse-link-header": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-1.0.1.tgz",
-      "integrity": "sha1-vt/g0hGK64S+deewJUGeyKYRQKc=",
-      "requires": {
-        "xtend": "~4.0.1"
-      }
-    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -3314,11 +3311,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
-    },
-    "xtend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
     "yn": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -37,10 +37,10 @@
   "devDependencies": {
     "@types/chai": "^4.1.6",
     "@types/highlight.js": "^9.12.3",
+    "@types/http-link-header": "^0.6.2",
     "@types/markdown-it": "0.0.5",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.11.4",
-    "@types/parse-link-header": "^1.0.0",
     "@types/sinon": "^5.0.3",
     "chai": "^4.2.0",
     "mocha": "^5.2.0",
@@ -60,7 +60,7 @@
     "@curveball/core": "^0.7.0",
     "csv-parse": "^2.5.0",
     "highlight.js": "^9.12.0",
-    "markdown-it": "^8.4.2",
-    "parse-link-header": "^1.0.1"
+    "http-link-header": "^0.8.0",
+    "markdown-it": "^8.4.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hal-browser",
-  "version": "0.5.6",
+  "version": "0.6.0",
   "description": "A HAL browser middleware",
   "main": "dist/index.js",
   "scripts": {

--- a/src/components/alternate.ts
+++ b/src/components/alternate.ts
@@ -1,6 +1,6 @@
+import url from 'url';
 import { Link, SureOptions } from '../types';
 import { getNavLinks, h } from '../util';
-import url from 'url';
 
 type Type = {
   [s: string]: {
@@ -55,7 +55,6 @@ export default function renderAlternate(links: Link[], options: SureOptions): st
     if (href.match(/^\/[^\/]/)) {
       const urlObj = url.parse(href, true);
       urlObj.query['_browser-accept'] = link.type;
-      console.log(urlObj);
       href = url.format(urlObj);
     }
 

--- a/src/components/alternate.ts
+++ b/src/components/alternate.ts
@@ -1,5 +1,6 @@
 import { Link, SureOptions } from '../types';
 import { getNavLinks, h } from '../util';
+import url from 'url';
 
 type Type = {
   [s: string]: {
@@ -48,8 +49,18 @@ export default function renderAlternate(links: Link[], options: SureOptions): st
     } else {
       label = link.title ? link.title : link.rel;
     }
+
+    let href = link.href;
+    // If the url is relative, we're adding our secret argument to make the Accept header work.
+    if (href.match(/^\/[^\/]/)) {
+      const urlObj = url.parse(href, true);
+      urlObj.query['_browser-accept'] = link.type;
+      console.log(urlObj);
+      href = url.format(urlObj);
+    }
+
     alternateHtml.push(
-      `<a href="${h(link.href)}" rel="${ h(link.rel) }" title="${ h(label) }"${cssClass}>${h(label)}</a>`
+      `<a href="${h(href)}" rel="${ h(link.rel) }" title="${ h(label) }"${cssClass}>${h(label)}</a>`
     );
 
   }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,6 @@
 import { Context } from '@curveball/core';
 import highlight from 'highlight.js';
-import parseLinkHeader from 'parse-link-header';
+import httpLinkHeader from 'http-link-header';
 import url from 'url';
 import {
   Link,
@@ -81,14 +81,15 @@ export function fetchLinks(ctx: Context, options: SureOptions): Link[] {
   result.push(...getHalLinks(ctx.response.body));
 
   const linkHeader = ctx.response.headers.get('Link');
+  console.log(linkHeader);
   if (linkHeader) {
-    const parsed = parseLinkHeader(linkHeader);
-    for (const [rel, info] of Object.entries(parsed)) {
+    const parsed = httpLinkHeader.parse(linkHeader);
+    for(const link of parsed.refs) {
       result.push({
-        rel: rel,
-        href: info.url,
-        title: info.title,
-        type: info.type
+        rel: link.rel,
+        href: link.uri,
+        title: link.title,
+        type: link.type
       });
     }
   }

--- a/src/util.ts
+++ b/src/util.ts
@@ -81,10 +81,9 @@ export function fetchLinks(ctx: Context, options: SureOptions): Link[] {
   result.push(...getHalLinks(ctx.response.body));
 
   const linkHeader = ctx.response.headers.get('Link');
-  console.log(linkHeader);
   if (linkHeader) {
     const parsed = httpLinkHeader.parse(linkHeader);
-    for(const link of parsed.refs) {
+    for (const link of parsed.refs) {
       result.push({
         rel: link.rel,
         href: link.uri,


### PR DESCRIPTION
This feature makes it easy to switch between multiple content-types in a browser, using the `?_hal-browser-accept` query parameter. This query parameter effectively overrides the `Accept` header.

This query parameter also automatically gets added for relative `alternate` links, making it possible for a single resource to switch between different content-types.